### PR TITLE
Add agent-first docs hub and AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS Guide (Index-First)
+
+This file is the **agent-oriented index** for navigating the `mono` repository.
+Use it as the first stop before scanning the whole tree.
+
+## 1) Fast Entry Points
+
+- Project overview for humans: [`README.md`](./README.md)
+- Docs hub for agents: [`docs/index.md`](./docs/index.md)
+- Technical docs map: [`docs/README.md`](./docs/README.md)
+
+## 2) Task → Where to Read
+
+### Understand architecture
+1. [`docs/architecture/system-overview.md`](./docs/architecture/system-overview.md)
+2. [`docs/architecture/task-runtime.md`](./docs/architecture/task-runtime.md)
+3. [`docs/architecture/tool-execution.md`](./docs/architecture/tool-execution.md)
+
+### Work on memory/retrieval
+1. [`docs/architecture/memory-system.md`](./docs/architecture/memory-system.md)
+2. [`docs/architecture/structured-memory-v2.md`](./docs/architecture/structured-memory-v2.md)
+3. [`docs/architecture/openviking-integration.md`](./docs/architecture/openviking-integration.md)
+4. [`docs/architecture/seekdb-integration.md`](./docs/architecture/seekdb-integration.md)
+
+### Work on runtime surfaces
+- CLI: [`docs/cli/commands.md`](./docs/cli/commands.md)
+- TUI: [`docs/tui/overview.md`](./docs/tui/overview.md)
+- IM platform: [`docs/im-platform/overview.md`](./docs/im-platform/overview.md)
+- Telegram control: [`docs/telegram-control/overview.md`](./docs/telegram-control/overview.md)
+
+### Check stable decisions first
+- ADR index folder: [`docs/decisions/`](./docs/decisions/)
+
+## 3) Repo Layout (high level)
+
+- `packages/*`: source packages
+- `docs/*`: maintainer and architecture docs
+- `test/*`: integration and package behavior tests
+- `.mono/*`: runtime identity/context/memory metadata
+
+## 4) Working Conventions for Agents
+
+- Prefer **Markdown docs first**, then inspect code.
+- Follow the ordered paths in [`docs/index.md`](./docs/index.md) when context is unclear.
+- If you change architecture or durable behavior, update docs and ADRs accordingly.
+- Keep edits minimal and scoped; avoid framework-heavy docs changes.
+
+## 5) Documentation Maintenance Checklist
+
+When adding/changing docs:
+- Update [`docs/index.md`](./docs/index.md) if navigation paths change.
+- Update [`docs/README.md`](./docs/README.md) if section responsibilities change.
+- Keep this file (`AGENTS.md`) aligned with new top-level navigation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,18 @@ The root [`README.md`](../README.md) stays intentionally lightweight. The detail
 11. [`cli/commands.md`](./cli/commands.md)
 12. [`architecture/skills-system.md`](./architecture/skills-system.md)
 
+
+## Markdown-Only Docs Framework
+
+The docs in this repository are intentionally **plain Markdown** so they stay easy to read for agents and contributors in terminals.
+
+- Entry point: [`docs/index.md`](./index.md)
+- Agent repo index: [`AGENTS.md`](../AGENTS.md)
+- Directory map and maintenance notes: this file (`docs/README.md`)
+- Section-level entry docs: `overview.md` or `README.md` within each folder
+
+When adding new docs, update `docs/index.md` and the relevant section index so navigation remains explicit without a site generator.
+
 ## Writing Rules
 
 When extending this doc set:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+# mono Docs Hub
+
+> Agent-first Markdown documentation index. No static-site framework required.
+
+This page is the entry point for reading and traversing all technical docs in this repository.
+
+## Quick Start Paths
+
+### Path A: Understand the system end-to-end
+1. [Repository Overview](./getting-started/repo-overview.md)
+2. [System Overview](./architecture/system-overview.md)
+3. [Task Runtime](./architecture/task-runtime.md)
+4. [Tool Execution](./architecture/tool-execution.md)
+5. [Commands](./cli/commands.md)
+
+### Path B: Focus on memory and retrieval
+1. [Memory System](./architecture/memory-system.md)
+2. [Structured Memory V2](./architecture/structured-memory-v2.md)
+3. [OpenViking Integration](./architecture/openviking-integration.md)
+4. [SeekDB Integration](./architecture/seekdb-integration.md)
+
+### Path C: Focus on runtime interfaces
+1. [CLI Overview](./cli/commands.md)
+2. [TUI Overview](./tui/overview.md)
+3. [IM Platform](./im-platform/overview.md)
+4. [Telegram Control](./telegram-control/overview.md)
+
+## Full Section Index
+- [Getting Started](./getting-started/repo-overview.md)
+- [Architecture](./architecture/system-overview.md)
+- [API Reference](./api/agent-core.md)
+- [CLI](./cli/commands.md)
+- [TUI](./tui/overview.md)
+- [IM Platform](./im-platform/overview.md)
+- [Telegram Control](./telegram-control/overview.md)
+- [Operations](./operations/troubleshooting.md)
+- [Decisions (ADR)](./decisions/0001-config-home-is-dot-mono.md)
+
+## Cross-Index Links
+- Agent repo index: [`../AGENTS.md`](../AGENTS.md)
+
+## Agent Usage Notes
+- Prefer following one of the ordered paths above instead of random document jumps.
+- Treat `overview.md` or `README.md` in each folder as the local index for that domain.
+- Use ADRs under `docs/decisions/` for long-lived design rationale.


### PR DESCRIPTION
### Motivation

- Provide an agent-oriented, index-first navigation layer to help agents and contributors find key docs without scanning the whole repo. 
- Make the docs intentionally plain Markdown so they are easy to read in terminals and by tooling that operates on raw files. 
- Surface high-level reading paths and maintenance guidance for documentation edits to reduce navigational friction.

### Description

- Add `AGENTS.md` as an agent-focused index and working-conventions guide that lists fast entry points, task→doc mappings, repo layout, and a docs maintenance checklist. 
- Add `docs/index.md` as the new docs hub with quick-start paths, a full section index, and agent usage notes to steer reading order. 
- Update `docs/README.md` to call out the Markdown-first docs framework and link to `AGENTS.md` and the new docs hub.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b515a5f074832b8c4bba68e0a3fa56)