### PR TITLE
Optimize SeekDB ancestor traversal queries

### DIFF
--- a/packages/seekdb-adapter/src/execution-memory.ts
+++ b/packages/seekdb-adapter/src/execution-memory.ts
@@ -68,8 +68,8 @@ export class SeekDbExecutionMemoryBackend implements ExecutionMemoryBackend {
 
     for (let depth = 0; depth < level; depth += 1) {
       const next: string[] = [];
-      for (const currentId of frontier) {
-        const record = await this.getById(currentId);
+      const records = await this.getByIds(frontier);
+      for (const record of records) {
         if (!record) {
           continue;
         }


### PR DESCRIPTION
### Motivation
- Remove an N+1 query pattern in ancestor traversal to reduce round-trips to the SeekDB runner and improve performance for deep/wide graph traversals.

### Description
- Refactored `SeekDbExecutionMemoryBackend.getAncestors` in `packages/seekdb-adapter/src/execution-memory.ts` to fetch each BFS frontier with a single `getByIds(frontier)` call instead of calling `getById` per node, batching reads per level.
- This is an internal performance optimization with no intended change to observable behavior.

### Testing
- Ran `pnpm -w vitest run test/seekdb-adapter.test.ts` and the `seekdb-adapter` tests passed (1 test file, 4 tests passed).
- An earlier attempt to run `pnpm -w test --filter seekdb-adapter` failed due to an incompatible CLI option, so the direct `vitest` invocation was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6191441e4832b87ea6b992ac6c7cc)