### PR TITLE
feat(docker): add healthcheck to compose for container monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,9 @@ services:
     stdin_open: true
     tty: true
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "test", "-f", "/app/packages/cli/dist/index.js"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
## Summary

Adds a Docker healthcheck to  that verifies the mono CLI dist file exists inside the container.

## Changes

- Added  block to compose service:
  - : verifies  exists
  - : 30s
  - : 10s  
  - : 3
  - : 10s

## Motivation

OpenClaw's gateway Docker image exposes  and  endpoints for container orchestration systems to monitor health. While mono doesn't have an HTTP server yet, adding a file-system based healthcheck enables Docker to:

1. Mark containers as unhealthy if the build is corrupted
2. Auto-restart unhealthy containers via the  policy
3. Provide visibility into container state via 

This is a first step toward parity with OpenClaw's container health story.

## Testing

```bash
docker compose up -d
docker inspect --format='{{.State.Health.Status}}' mono-mono-1
```

Should show `healthy` after the container starts.

## Notes

- Future enhancement: add an HTTP health endpoint inside the mono CLI for deeper health checks
- Alternative: could use  or similar if a version command exists