### PR TITLE
fix(docker): add dev-mode-compatible healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,9 @@ services:
     stdin_open: true
     tty: true
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "sh", "-c", "[ -f /app/packages/cli/dist/index.js ] || [ -f /workspace/packages/cli/src/bin.ts ]"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
## Summary

Fixes regression where healthcheck was removed in commit b87691e when docker-compose.yml was rewritten for dev mode.

## Changes

- Re-add healthcheck with dev-mode compatibility
- Healthcheck now checks for either:
  - Prod mode: `/app/packages/cli/dist/index.js`
  - Dev mode: `/workspace/packages/cli/src/bin.ts`

## Testing

The healthcheck should pass in both production (built dist) and development (tsx source) modes.

## Notes

- Closes stale PR #18 which had the original healthcheck that broke dev mode
- Alternative to PR #18: more flexible approach that works in both modes