### PR TITLE
fix(docker): sync pnpm-lock.yaml with telegram-control/@mono/prompts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@mono/im-platform':
         specifier: workspace:*
         version: link:../im-platform
+      '@mono/prompts':
+        specifier: workspace:*
+        version: link:../prompts
       '@mono/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary

Docker build was failing with `ERR_PNPM_OUTDATED_LOCKFILE` because `packages/telegram-control/package.json` added a `@mono/prompts: workspace:*` dependency in commit df17301 but the `pnpm-lock.yaml` was not regenerated.

## What changed

`pnpm-lock.yaml` — 3 lines added to `packages/telegram-control:` dependencies section:
```
'@mono/prompts':
  specifier: workspace:*
  version: link:../prompts
```

## Verification

```bash
docker compose build mono  # Before: ERR_PNPM_OUTDATED_LOCKFILE
docker compose build mono  # After: succeeds ✓
```

## Testing

- [x] `pnpm install` — 13 packages added
- [x] `pnpm run build` — succeeds
- [x] `docker compose build mono` — succeeds