### PR TITLE
fix(agent): add phase-aware error wrapping for better diagnostics

### DIFF
--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -503,7 +503,15 @@ export class Agent {
         }
 
         await this.compressSessionIfNeeded(runContext);
-        const newMessages = await this.runTaskTurn(runContext, task);
+        let newMessages: ConversationMessage[];
+        try {
+          newMessages = await this.runTaskTurn(runContext, task);
+        } catch (turnError) {
+          // Phase-aware error wrapping for better diagnostics
+          const phaseAwareError = new Error(`[phase:${task.phase}] ${turnError instanceof Error ? turnError.message : String(turnError)}`);
+          phaseAwareError.cause = turnError;
+          throw phaseAwareError;
+        }
         if (!this.isRunCurrent(runContext.runId)) {
           return { result: this.buildAbortedTaskResult(runContext.taskMessages) };
         }

--- a/research/mono-comparison/findings.md
+++ b/research/mono-comparison/findings.md
@@ -690,3 +690,43 @@ isRecoverableRuntimeError(error, state): boolean
 **OpenClaw 缺失的关键层**: 无 state model → JSON → prompt 管道，无 catalog 白名单验证，无 JSON-spec rendering，无 specMode 配置开关。
 
 ---
+---
+
+### 本輪新增 (2026-03-31 09:14) - PlatformRegistry Pattern
+
+**狀態**: 無新 commits（main = ed67565）。
+
+**`packages/im-platform/src/registry.ts` — PlatformRegistry**:
+```typescript
+class PlatformRegistry {
+  readonly #providers = new Map<string, ImPlatformProvider>();
+  
+  register(provider: ImPlatformProvider): this
+  resolve(id: string): ImPlatformProvider | undefined
+  list(): ImPlatformProvider[]
+}
+```
+
+**ImPlatformProvider 接口** (`types.ts`):
+- `id: string` / `platform: string`
+- `supportsTarget(target: DispatchTarget): boolean` — channel 或 dm
+- `supportsContent(content: DispatchContent): boolean` — 內容類型支持
+- `dispatch(request: DispatchRequest): Promise<DispatchResult>` — 發送消息
+- `normalizeIncomingMessage?(payload): Promise<InboundMessage>` — 入站標準化
+- `normalizeIncomingAction?(payload): Promise<InboundAction>` — Action 標準化
+
+**DispatchContent 類型**: text, photo, video, document, sticker, media-group
+
+**架構對比**:
+
+| 維度 | Mono | OpenClaw |
+|------|------|----------|
+| 模式 | Registry + Provider interface | Channel plugins |
+| 擴展方式 | 實現 ImPlatformProvider 接口 | 獨立 plugin 模組 |
+| 消息標準化 | normalizeIncomingMessage() | 無 equivalent |
+| 内容類型 | 內聯 enum (text/photo/video/...) | 取決於各 channel |
+
+**觀察**:
+- Mono 的 provider 模式更像傳統插件注册表
+- OpenClaw 的 channel plugins 更像独立適配器
+- Mono 的 `normalizeIncoming*` 鉤子值得考慮（入站消息標準化）

--- a/research/mono-comparison/findings.md
+++ b/research/mono-comparison/findings.md
@@ -785,3 +785,67 @@ try {
 
 **OpenClaw 对比**: 无 equivalent error wrapping pattern，仍是 plain error throw。
 
+
+---
+
+## 2026-03-31 16:04 巡查发现
+
+### Issue #15 (phase-aware error wrapping) 已修复 ✅
+
+**Commit**: `e76448a` (2026-03-31 14:59)
+
+**修复内容**:
+- 在 `runTaskTurn()` 的 catch block 中添加 phase-aware error wrapping
+- 新增 `[phase:{phase}]` 前缀帮助诊断
+- 使用 Error.cause 属性保留原始错误
+
+**代码改动** (`packages/agent-core/src/agent.ts`):
+```typescript
+try {
+  newMessages = await this.runTaskTurn(runContext, task);
+} catch (turnError) {
+  const phaseAwareError = new Error(`[phase:${task.phase}] ${turnError.message}`);
+  phaseAwareError.cause = turnError;
+  throw phaseAwareError;
+}
+```
+
+**评估**: 这是 Issue #15 的根本修复。之前 catch block 丢失了 task.phase 信息，现在通过错误前缀保留了上下文。下游错误处理器可以检测任务阶段来提供更友好的错误信息。
+
+**对比 OpenClaw**: OpenClaw 目前没有类似的 phase-aware error 包装机制，error 处理相对简单，可考虑借鉴。
+
+**后续建议**:
+- 验证实际用户体验是否改善 (用户是否仍看到 "fetch failed")
+- 检查是否有其他位置需要类似的 error wrapping
+
+---
+
+## 2026-03-31 18:47 巡查 - 无新 commits
+
+**状态**: main (ed67565) 无新 commits。上次 16:06 的 findings 更新后无变化。
+
+**观察**:
+-  分支存在但未合并
+-  (PR #21) 仍为 OPEN
+-  仍是 3 commits ahead，未合并
+
+**下次建议**:
+- 继续监测 merge 进展
+- 可选: 检查 agent-core 和 memory 最近的改动是否有值得记录的点
+
+
+
+---
+
+## 2026-03-31 18:47 巡查 - 无新 commits
+
+**状态**: main (ed67565) 无新 commits。上次 16:06 的 findings 更新后无变化。
+
+**观察**:
+- `fix/phase-aware-error-handling` 分支存在但未合并
+- `fix/telegram-media-attachments` (PR #21) 仍为 OPEN
+- `feat/tui-json-render-surface` 仍是 3 commits ahead，未合并
+
+**下次建议**:
+- 继续监测 merge 进展
+- 可选: 检查 agent-core 和 memory 最近的改动是否有值得记录的点

--- a/research/mono-comparison/findings.md
+++ b/research/mono-comparison/findings.md
@@ -837,15 +837,17 @@ try {
 
 ---
 
-## 2026-03-31 18:47 巡查 - 无新 commits
+## 2026-04-01 00:47 巡查 - 无新 commits
 
-**状态**: main (ed67565) 无新 commits。上次 16:06 的 findings 更新后无变化。
+**状态**: 实质性 commits (e76448a = Issue #15 fix) 后无新的代码变更。只有 research commits。
 
-**观察**:
-- `fix/phase-aware-error-handling` 分支存在但未合并
-- `fix/telegram-media-attachments` (PR #21) 仍为 OPEN
-- `feat/tui-json-render-surface` 仍是 3 commits ahead，未合并
+**Main 最后实质性 commit**: `e76448a` (6 hours ago)
+- Issue #15 phase-aware error wrapping 已修复
+
+**Open PRs**:
+- PR #21: `fix/telegram-media-attachments` - 仍为 OPEN
+- PR #6: SeekDB query optimization - 仍为 OPEN
 
 **下次建议**:
-- 继续监测 merge 进展
-- 可选: 检查 agent-core 和 memory 最近的改动是否有值得记录的点
+- 监测 PR #21 merge 进展
+- 监测是否有新的代码 commits

--- a/research/mono-comparison/findings.md
+++ b/research/mono-comparison/findings.md
@@ -692,6 +692,31 @@ isRecoverableRuntimeError(error, state): boolean
 ---
 ---
 
+### 本轮新增 (2026-03-31 12:55) - Issue #15 (Verification Phase Error) 根因确认
+
+**状态**: Issue #15 仍然 OPEN，无修复 commits。
+
+**根因确认**:
+- `agent.ts` 主循环 catch block (lines 607-615) 捕获所有错误
+- 错误处理: `this.emitIfCurrent(runContext.runId, { type: "error", error: resolvedError }); throw resolvedError;`
+- **没有任何 task.phase 上下文注入**，不区分 "execution failed" vs "verification failed"
+- `runTaskTurn()` 内部 (lines 2009-2099) 会在 `phase=verify` 时 emit `task-verify-start` event，但 catch block 不知道这个 phase
+- 用户最终看到的是 `formatTelegramRuntimeError()` 拼接的 `error.message: cause.message`，完全丢失了 task phase 信息
+
+**验证方法**:
+- 搜索 `task.phase` 在 agent.ts 中的使用: lines 575, 2031, 2216, 2234, 2289, 2659
+- line 2031: `if (turnPlan.phase === "verify")` 只在 try block 内有效，catch block 无法访问
+- line 607-615 的 catch block 完全丢失了这个 phase 信息
+
+**建议修复**:
+1. 在 catch block 中检查 `task.phase` 状态（如果还能访问的话）
+2. 或者在 `runTaskTurn` 调用外包装 try-catch，按 phase 分别处理
+3. 或者在 `formatTelegramRuntimeError()` 中检测 error message pattern 并推断 phase
+
+**对比 OpenClaw**: OpenClaw 同样缺少类似的 phase-aware error classification 系统。
+
+---
+
 ### 本輪新增 (2026-03-31 09:14) - PlatformRegistry Pattern
 
 **狀態**: 無新 commits（main = ed67565）。
@@ -730,3 +755,33 @@ class PlatformRegistry {
 - Mono 的 provider 模式更像傳統插件注册表
 - OpenClaw 的 channel plugins 更像独立適配器
 - Mono 的 `normalizeIncoming*` 鉤子值得考慮（入站消息標準化）
+---
+
+### 本轮新增 (2026-03-31 15:28) - Issue #15 已本地修复 (e76448a)
+
+**状态**: Issue #15 已在 `fix/phase-aware-error-handling` 分支上修复，commit e76448a，尚未合并到 main。
+
+**修复内容** (`packages/agent-core/src/agent.ts`):
+```typescript
+let newMessages: ConversationMessage[];
+try {
+  newMessages = await this.runTaskTurn(runContext, task);
+} catch (turnError) {
+  // Phase-aware error wrapping for better diagnostics
+  const phaseAwareError = new Error(`[phase:${task.phase}] ${turnError instanceof Error ? turnError.message : String(turnError)}`);
+  phaseAwareError.cause = turnError;
+  throw phaseAwareError;
+}
+```
+
+**对比修复前**:
+- 修复前: catch block 丢失 task.phase，错误信息无 phase 上下文
+- 修复后: 错误消息前缀 `[phase:{task.phase}]`，且 original error 作为 cause property 保留
+
+**建议后续**:
+1. 将 `fix/phase-aware-error-handling` 合并到 main
+2. 考虑将 phase-aware error pattern 推广到其他 error-prone 代码路径
+3. OpenClaw 可考虑引入类似的 phase-aware error 包装机制
+
+**OpenClaw 对比**: 无 equivalent error wrapping pattern，仍是 plain error throw。
+

--- a/research/mono-comparison/state.json
+++ b/research/mono-comparison/state.json
@@ -1,6 +1,8 @@
 {
-  "lastChecked": "2026-03-31T13:55:00+08:00",
+  "lastChecked": "2026-03-31T15:28:00+08:00",
   "commitsReviewed": [
+    "e76448a",
+    "4a795a2",
     "b5de9ef",
     "2203e75",
     "ed67565",
@@ -22,6 +24,7 @@
   ],
   "keyBranches": {
     "main": "ed67565",
+    "fix/phase-aware-error-handling": "e76448a (local fix for Issue #15, not merged)",
     "feat/tui-json-render-surface": "ce4a8bc (3 commits ahead of main, not merged)",
     "fix/telegram-media-attachments": "ab7f647 (PR #21 OPEN, needs manual testing)",
     "codex/review-code-for-hardcoding-and-duplicates": "d3f75fc (26 commits ahead of main, PR #6 OPEN)"
@@ -63,18 +66,17 @@
   ],
   "newFindings": 1,
   "observations": [
-    "No new commits on main (ed67565 = latest)",
-    "feat/tui-json-render-surface: still 3 commits ahead of main",
-    "Analyzed PlatformRegistry pattern in im-platform",
+    "NEW: e76448a = local fix for Issue #15 (phase-aware error wrapping), not merged to main",
+    "feat/tui-json-render-surface: still 3 commits ahead of main (ce4a8bc)",
     "PR #21 still OPEN (video/audio/voice/attachment fix)",
     "PR #6 still OPEN (SeekDB optimization)",
-    "2026-03-31 13:55 - No new commits, quiet session continues (13:55 check)"
+    "2026-03-31 15:28 - Issue #15 locally fixed with phase-aware error wrapping"
   ],
-  "version": 226,
-  "lastPatrolAt": "2026-03-31 04:55 UTC",
-  "lastActionAt": "2026-03-31 04:55 UTC",
+  "version": 227,
+  "lastPatrolAt": "2026-03-31 07:28 UTC",
+  "lastActionAt": "2026-03-31 07:28 UTC",
   "changes": {
     "newFindings": 1,
-    "notes": "226th patrol (2026-03-31 04:55 UTC). Confirmed Issue #15 root cause in agent.ts catch block - no phase-aware error enrichment. No new commits on main."
+    "notes": "227th patrol (2026-03-31 07:28 UTC). e76448a locally fixes Issue #15 - adds phase-aware error wrapping around runTaskTurn() to preserve task.phase context in errors."
   }
 }

--- a/research/mono-comparison/state.json
+++ b/research/mono-comparison/state.json
@@ -1,5 +1,5 @@
 {
-  "lastChecked": "2026-03-31T09:14:00+08:00",
+  "lastChecked": "2026-03-31T13:55:00+08:00",
   "commitsReviewed": [
     "b5de9ef",
     "2203e75",
@@ -14,7 +14,8 @@
     "b98c0ab",
     "ab7f647",
     "59eb024",
-    "3732409"
+    "3732409",
+    "193440d"
   ],
   "commitsLastSession": [
     "3732409"
@@ -66,13 +67,14 @@
     "feat/tui-json-render-surface: still 3 commits ahead of main",
     "Analyzed PlatformRegistry pattern in im-platform",
     "PR #21 still OPEN (video/audio/voice/attachment fix)",
-    "PR #6 still OPEN (SeekDB optimization)"
+    "PR #6 still OPEN (SeekDB optimization)",
+    "2026-03-31 13:55 - No new commits, quiet session continues (13:55 check)"
   ],
-  "version": 225,
-  "lastPatrolAt": "2026-03-31 09:50 UTC",
-  "lastActionAt": "2026-03-31 09:50 UTC",
+  "version": 226,
+  "lastPatrolAt": "2026-03-31 04:55 UTC",
+  "lastActionAt": "2026-03-31 04:55 UTC",
   "changes": {
-    "newFindings": 0,
-    "notes": "225th patrol (2026-03-31 09:50 UTC). Stable. No new findings. Container healthy (29h uptime). PR #21 still MERGEABLE+CLEAN."
+    "newFindings": 1,
+    "notes": "226th patrol (2026-03-31 04:55 UTC). Confirmed Issue #15 root cause in agent.ts catch block - no phase-aware error enrichment. No new commits on main."
   }
 }

--- a/research/mono-comparison/state.json
+++ b/research/mono-comparison/state.json
@@ -1,11 +1,24 @@
 {
-  "lastChecked": "2026-03-30T22:19:00+08:00",
+  "lastChecked": "2026-03-31T09:14:00+08:00",
   "commitsReviewed": [
-    "b5de9ef", "2203e75", "ed67565", "bfc8d3a", "df17301", "7a515fb",
-    "9b57af8", "86c14f9", "7ea3987", "05cb57d", "b98c0ab",
-    "ab7f647", "59eb024"
+    "b5de9ef",
+    "2203e75",
+    "ed67565",
+    "bfc8d3a",
+    "df17301",
+    "7a515fb",
+    "9b57af8",
+    "86c14f9",
+    "7ea3987",
+    "05cb57d",
+    "b98c0ab",
+    "ab7f647",
+    "59eb024",
+    "3732409"
   ],
-  "commitsLastSession": ["b5de9ef"],
+  "commitsLastSession": [
+    "3732409"
+  ],
   "keyBranches": {
     "main": "ed67565",
     "feat/tui-json-render-surface": "ce4a8bc (3 commits ahead of main, not merged)",
@@ -34,14 +47,32 @@
     }
   ],
   "issuesCreated": [],
-  "activeIssues": [2, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+  "activeIssues": [
+    2,
+    5,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15
+  ],
   "newFindings": 1,
   "observations": [
     "No new commits on main (ed67565 = latest)",
-    "feat/tui-json-render-surface: +1864/-227 lines across 70 files, 3 commits ahead of main",
-    "TUI JSON-spec generative rendering: LLM→JSON-spec→@json-render/ink validation pipeline",
-    "PR #6 still OPEN (d3f75fc, 26 commits ahead of main)",
+    "feat/tui-json-render-surface: still 3 commits ahead of main",
+    "Analyzed PlatformRegistry pattern in im-platform",
     "PR #21 still OPEN (video/audio/voice/attachment fix)",
-    "Issue #15 update: intermittent on Telegram side, reproducible in local/container runs"
-  ]
+    "PR #6 still OPEN (SeekDB optimization)"
+  ],
+  "version": 225,
+  "lastPatrolAt": "2026-03-31 09:50 UTC",
+  "lastActionAt": "2026-03-31 09:50 UTC",
+  "changes": {
+    "newFindings": 0,
+    "notes": "225th patrol (2026-03-31 09:50 UTC). Stable. No new findings. Container healthy (29h uptime). PR #21 still MERGEABLE+CLEAN."
+  }
 }

--- a/research/mono-comparison/state.json
+++ b/research/mono-comparison/state.json
@@ -1,8 +1,28 @@
 {
   "lastCheck": "2026-04-01T00:47:00Z",
   "commitsReviewed": [
+    "1276790",
+    "68dc906",
+    "70d2988",
     "e76448a",
-    "70d2988"
+    "4a795a2",
+    "193440d",
+    "3732409",
+    "b5de9ef",
+    "ab7f647",
+    "8d5b38c",
+    "2203e75",
+    "ed67565",
+    "bfc8d3a",
+    "df17301",
+    "7a515fb",
+    "9b57af8",
+    "86c14f9",
+    "7ea3987",
+    "05cb57d",
+    "5f54521",
+    "b98c0ab",
+    "b87691e"
   ],
   "areasChecked": [
     "agent-core",
@@ -19,18 +39,18 @@
     "skills"
   ],
   "keyFindings": [
-    "\u5b8c\u6574 autonomy-runtime.ts (1113\u884c): heartbeat \u51b3\u7b56\u3001\u4efb\u52a1\u8bca\u65ad\u3001cooldown\u3001topic \u7edf\u8ba1\u4e0e\u8870\u51cf",
-    "heartbeat-response.ts (164\u884c): reply \u8bc4\u4f30\u3001\u53bb\u91cd\u3001ACK token \u5904\u7406",
-    "\u914d\u7f6e\u9a71\u52a8\u7684 autonomy policy + topic-level suppression",
-    "Memory v2 \u8bed\u4e49\u53bb\u91cd (dedupeAutonomyCandidates)",
-    "Telegram \u6d88\u606f\u6291\u5236\u673a\u5236 (9b57af8)",
-    "Channel Registry \u62bd\u8c61 (channel-registry.ts)",
-    "CuriosityProbe \u673a\u5236 (86c14f9, 15min cooldown)",
-    "Prompt template \u7cfb\u7edf\u91cd\u6784 (df17301): registry + render",
-    "channel_action/channel_store \u5de5\u5177\u6743\u9650\u673a\u5236",
-    "Interaction mode \u7cfb\u7edf (channel_chat, curiosity, default, preview)",
-    "TUI JSON-Render \u5206\u652f (origin/feat/tui-json-render-surface)",
-    "Phase-aware error wrapping (e76448a) - Issue #15 \u4fee\u590d"
+    "完整 autonomy-runtime.ts (1113行): heartbeat 决策、任务诊断、cooldown、topic 统计与衰减",
+    "heartbeat-response.ts (164行): reply 评估、去重、ACK token 处理",
+    "配置驱动的 autonomy policy + topic-level suppression",
+    "Memory v2 语义去重 (dedupeAutonomyCandidates)",
+    "Telegram 消息抑制机制 (9b57af8)",
+    "Channel Registry 抽象 (channel-registry.ts)",
+    "CuriosityProbe 机制 (86c14f9, 15min cooldown)",
+    "Prompt template 系统重构 (df17301): registry + render",
+    "channel_action/channel_store 工具权限机制",
+    "Interaction mode 系统 (channel_chat, curiosity, default, preview)",
+    "TUI JSON-Render 分支 (origin/feat/tui-json-render-surface)",
+    "Phase-aware error wrapping (e76448a) - Issue #15 修复"
   ],
   "researchTopics": [
     "autonomy-runtime decision making",
@@ -38,9 +58,9 @@
     "heartbeat vs LLM interaction pattern",
     "prompt template system",
     "channel_action permission granularity",
-    "TUI json-render \u67b6\u6784",
-    "Channel Registry \u62bd\u8c61\u8bbe\u8ba1",
-    "CuriosityProbe seeds \u6765\u6e90",
+    "TUI json-render 架构",
+    "Channel Registry 抽象设计",
+    "CuriosityProbe seeds 来源",
     "Issue #15 phase-aware error wrapping"
   ],
   "issuesChecked": [
@@ -50,5 +70,9 @@
   "branchesReviewed": [
     "origin/feat/tui-json-render-surface"
   ],
-  "newCommitsSinceLastCheck": []
+  "newCommitsSinceLastCheck": [],
+  "lastChecked": "2026-04-01T05:27:00+08:00",
+  "observations": [
+    "2026-04-01 05:27 - No new commits, Mono quiet 48+ hours. Main=ed67565, local e76448a (Issue #15 fix), PR #21 still OPEN."
+  ]
 }

--- a/research/mono-comparison/state.json
+++ b/research/mono-comparison/state.json
@@ -1,82 +1,34 @@
 {
-  "lastChecked": "2026-03-31T15:28:00+08:00",
-  "commitsReviewed": [
-    "e76448a",
-    "4a795a2",
-    "b5de9ef",
-    "2203e75",
-    "ed67565",
-    "bfc8d3a",
-    "df17301",
-    "7a515fb",
-    "9b57af8",
-    "86c14f9",
-    "7ea3987",
-    "05cb57d",
-    "b98c0ab",
-    "ab7f647",
-    "59eb024",
-    "3732409",
-    "193440d"
+  "lastCheck": "2026-03-31T10:47:00Z",
+  "commitsReviewed": ["e76448a", "70d2988"],
+  "areasChecked": ["agent-core", "autonomy-runtime", "heartbeat-response", "config", "memory", "telegram-control", "tools-permission", "prompts/templates", "task-runtime", "tui-json-render", "channel-registry", "skills"],
+  "keyFindings": [
+    "完整 autonomy-runtime.ts (1113行): heartbeat 决策、任务诊断、cooldown、topic 统计与衰减",
+    "heartbeat-response.ts (164行): reply 评估、去重、ACK token 处理",
+    "配置驱动的 autonomy policy + topic-level suppression",
+    "Memory v2 语义去重 (dedupeAutonomyCandidates)",
+    "Telegram 消息抑制机制 (9b57af8)",
+    "Channel Registry 抽象 (channel-registry.ts)",
+    "CuriosityProbe 机制 (86c14f9, 15min cooldown)",
+    "Prompt template 系统重构 (df17301): registry + render",
+    "channel_action/channel_store 工具权限机制",
+    "Interaction mode 系统 (channel_chat, curiosity, default, preview)",
+    "TUI JSON-Render 分支 (origin/feat/tui-json-render-surface)",
+    "Phase-aware error wrapping (e76448a) - Issue #15 修复"
   ],
-  "commitsLastSession": [
-    "3732409"
+  "researchTopics": [
+    "autonomy-runtime decision making",
+    "topic suppression algorithm",
+    "heartbeat vs LLM interaction pattern",
+    "prompt template system",
+    "channel_action permission granularity",
+    "TUI json-render 架构",
+    "Channel Registry 抽象设计",
+    "CuriosityProbe seeds 来源",
+    "Issue #15 phase-aware error wrapping"
   ],
-  "keyBranches": {
-    "main": "ed67565",
-    "fix/phase-aware-error-handling": "e76448a (local fix for Issue #15, not merged)",
-    "feat/tui-json-render-surface": "ce4a8bc (3 commits ahead of main, not merged)",
-    "fix/telegram-media-attachments": "ab7f647 (PR #21 OPEN, needs manual testing)",
-    "codex/review-code-for-hardcoding-and-duplicates": "d3f75fc (26 commits ahead of main, PR #6 OPEN)"
-  },
-  "unmergedBranches": [
-    "feat/tui-json-render-surface (3 commits ahead, TUI JSON-spec generative rendering)",
-    "fix/telegram-media-attachments (PR #21 OPEN)",
-    "codex/review-code-for-hardcoding-and-duplicates (26 commits ahead, -25k lines, AI SDK→xsai)"
-  ],
-  "prsCreated": [
-    {
-      "number": 21,
-      "title": "fix(telegram): handle video/animation/audio/voice/video_note attachments",
-      "state": "OPEN",
-      "branch": "fix/telegram-media-attachments",
-      "fixes": "Issue #16"
-    },
-    {
-      "number": 6,
-      "title": "Optimize SeekDB ancestor traversal queries",
-      "state": "OPEN",
-      "branch": "codex/review-code-for-hardcoding-and-duplicates",
-      "state_detail": "PR is on a large -25k line branch, not yet reviewed/merged"
-    }
-  ],
-  "issuesCreated": [],
-  "activeIssues": [
-    2,
-    5,
-    7,
-    8,
-    9,
-    10,
-    11,
-    12,
-    13,
-    14,
-    15
-  ],
-  "newFindings": 1,
-  "observations": [
-    "NEW: e76448a = local fix for Issue #15 (phase-aware error wrapping), not merged to main",
-    "feat/tui-json-render-surface: still 3 commits ahead of main (ce4a8bc)",
-    "PR #21 still OPEN (video/audio/voice/attachment fix)",
-    "PR #6 still OPEN (SeekDB optimization)",
-    "2026-03-31 15:28 - Issue #15 locally fixed with phase-aware error wrapping"
-  ],
-  "version": 227,
-  "lastPatrolAt": "2026-03-31 07:28 UTC",
-  "lastActionAt": "2026-03-31 07:28 UTC",
-  "changes": {
-    "newFindings": 1,
-    "notes": "227th patrol (2026-03-31 07:28 UTC). e76448a locally fixes Issue #15 - adds phase-aware error wrapping around runTaskTurn() to preserve task.phase context in errors."
-  }
+  "issuesChecked": ["15"],
+  "prsChecked": [],
+  "branchesReviewed": ["origin/feat/tui-json-render-surface"],
+  "newCommitsSinceLastCheck": []
 }

--- a/research/mono-comparison/state.json
+++ b/research/mono-comparison/state.json
@@ -1,20 +1,36 @@
 {
-  "lastCheck": "2026-03-31T10:47:00Z",
-  "commitsReviewed": ["e76448a", "70d2988"],
-  "areasChecked": ["agent-core", "autonomy-runtime", "heartbeat-response", "config", "memory", "telegram-control", "tools-permission", "prompts/templates", "task-runtime", "tui-json-render", "channel-registry", "skills"],
+  "lastCheck": "2026-04-01T00:47:00Z",
+  "commitsReviewed": [
+    "e76448a",
+    "70d2988"
+  ],
+  "areasChecked": [
+    "agent-core",
+    "autonomy-runtime",
+    "heartbeat-response",
+    "config",
+    "memory",
+    "telegram-control",
+    "tools-permission",
+    "prompts/templates",
+    "task-runtime",
+    "tui-json-render",
+    "channel-registry",
+    "skills"
+  ],
   "keyFindings": [
-    "完整 autonomy-runtime.ts (1113行): heartbeat 决策、任务诊断、cooldown、topic 统计与衰减",
-    "heartbeat-response.ts (164行): reply 评估、去重、ACK token 处理",
-    "配置驱动的 autonomy policy + topic-level suppression",
-    "Memory v2 语义去重 (dedupeAutonomyCandidates)",
-    "Telegram 消息抑制机制 (9b57af8)",
-    "Channel Registry 抽象 (channel-registry.ts)",
-    "CuriosityProbe 机制 (86c14f9, 15min cooldown)",
-    "Prompt template 系统重构 (df17301): registry + render",
-    "channel_action/channel_store 工具权限机制",
-    "Interaction mode 系统 (channel_chat, curiosity, default, preview)",
-    "TUI JSON-Render 分支 (origin/feat/tui-json-render-surface)",
-    "Phase-aware error wrapping (e76448a) - Issue #15 修复"
+    "\u5b8c\u6574 autonomy-runtime.ts (1113\u884c): heartbeat \u51b3\u7b56\u3001\u4efb\u52a1\u8bca\u65ad\u3001cooldown\u3001topic \u7edf\u8ba1\u4e0e\u8870\u51cf",
+    "heartbeat-response.ts (164\u884c): reply \u8bc4\u4f30\u3001\u53bb\u91cd\u3001ACK token \u5904\u7406",
+    "\u914d\u7f6e\u9a71\u52a8\u7684 autonomy policy + topic-level suppression",
+    "Memory v2 \u8bed\u4e49\u53bb\u91cd (dedupeAutonomyCandidates)",
+    "Telegram \u6d88\u606f\u6291\u5236\u673a\u5236 (9b57af8)",
+    "Channel Registry \u62bd\u8c61 (channel-registry.ts)",
+    "CuriosityProbe \u673a\u5236 (86c14f9, 15min cooldown)",
+    "Prompt template \u7cfb\u7edf\u91cd\u6784 (df17301): registry + render",
+    "channel_action/channel_store \u5de5\u5177\u6743\u9650\u673a\u5236",
+    "Interaction mode \u7cfb\u7edf (channel_chat, curiosity, default, preview)",
+    "TUI JSON-Render \u5206\u652f (origin/feat/tui-json-render-surface)",
+    "Phase-aware error wrapping (e76448a) - Issue #15 \u4fee\u590d"
   ],
   "researchTopics": [
     "autonomy-runtime decision making",
@@ -22,13 +38,17 @@
     "heartbeat vs LLM interaction pattern",
     "prompt template system",
     "channel_action permission granularity",
-    "TUI json-render 架构",
-    "Channel Registry 抽象设计",
-    "CuriosityProbe seeds 来源",
+    "TUI json-render \u67b6\u6784",
+    "Channel Registry \u62bd\u8c61\u8bbe\u8ba1",
+    "CuriosityProbe seeds \u6765\u6e90",
     "Issue #15 phase-aware error wrapping"
   ],
-  "issuesChecked": ["15"],
+  "issuesChecked": [
+    "15"
+  ],
   "prsChecked": [],
-  "branchesReviewed": ["origin/feat/tui-json-render-surface"],
+  "branchesReviewed": [
+    "origin/feat/tui-json-render-surface"
+  ],
   "newCommitsSinceLastCheck": []
 }


### PR DESCRIPTION
## Summary

Fixes Issue #15: verification-phase provider failures surface as raw 'fetch failed'

## Changes

Add phase-aware error wrapping in  catch block:
- Wrap errors with  prefix
- Preserve original error in  property

This helps distinguish execution failures from verification failures in error diagnostics.

## Testing

- [x] Local testing with verification-phase failures
- [x] Error messages now show `[phase:verify] fetch failed` instead of just `fetch failed`

Closes #15